### PR TITLE
Add rerender test for NumberOfEvents

### DIFF
--- a/src/__tests__/NumberOfEvents.test.js
+++ b/src/__tests__/NumberOfEvents.test.js
@@ -24,6 +24,20 @@ describe("<NumberOfEvents />", () => {
     expect(input).toHaveValue(42);
   });
 
+  test("updates the input value when the currentNOE prop changes", () => {
+    const { rerender } = render(
+      <NumberOfEvents currentNOE={32} setCurrentNOE={jest.fn()} />
+    );
+
+    const input = screen.getByRole("spinbutton", {
+      name: /number of events:/i,
+    });
+    expect(input).toHaveValue(32);
+
+    rerender(<NumberOfEvents currentNOE={15} setCurrentNOE={jest.fn()} />);
+    expect(screen.getByRole("spinbutton", { name: /number of events:/i })).toHaveValue(15);
+  });
+
   test("calls setCurrentNOE with the final value when user types", async () => {
     const user = userEvent.setup();
     const { input, mockSet } = setup(32);


### PR DESCRIPTION
## Summary
- check that `<NumberOfEvents>` updates value when props change

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848a7dc93d4832e85cfeec721abd26e